### PR TITLE
Libraw-Cmake import either mem_sample or mem_image_sample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,7 +671,13 @@ ENDMACRO(LIBRAW_BUILD_SAMPLES)
 IF(ENABLE_EXAMPLES)
 
     LIBRAW_BUILD_SAMPLES(simple_dcraw.cpp raw)
-    LIBRAW_BUILD_SAMPLES(mem_image_sample.cpp raw)
+
+    if(EXISTS mem_image.cpp)
+        LIBRAW_BUILD_SAMPLES(mem_image.cpp raw)
+    else()
+        LIBRAW_BUILD_SAMPLES(mem_image_sample.cpp raw)
+    endif()
+
     LIBRAW_BUILD_SAMPLES(dcraw_emu.cpp raw)
     LIBRAW_BUILD_SAMPLES(4channels.cpp raw)
     LIBRAW_BUILD_SAMPLES(unprocessed_raw.cpp raw)


### PR DESCRIPTION
Fix related to this issue
https://github.com/LibRaw/LibRaw-cmake/issues/11

We check if we are working on the version of libraw using either mem_sample.cpp or mem_image_sample.cpp to make Libraw-Cmake compatible with both.