### PR TITLE
Travis CI: Update environment, use GCC 10 & add Arm64 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 language: cpp
 dist: bionic
 
+addons:
+  apt:
+    update: true
+    sources:
+      - sourceline: "ppa:ubuntu-toolchain-r/test"
+    packages:
+      - gcc-10 g++-10
+
 env:
   global:
     - LIBRAW_GIT="git://github.com/LibRaw/LibRaw.git"
     - LIBRAW_GPL2_GIT="git://github.com/LibRaw/LibRaw-demosaic-pack-GPL2.git"
     - LIBRAW_GPL3_GIT="git://github.com/LibRaw/LibRaw-demosaic-pack-GPL3.git"
-    
+    - CC=gcc-10 CXX=g++-10
+
 script:
   - cd ..
   - git clone $LIBRAW_GIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: bionic
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 dist: bionic
+arch:
+ - amd64
+ - arm64
 
 addons:
   apt:


### PR DESCRIPTION
 - Updates the build environment to Ubuntu 18.04 Bionic
 - Uses GCC 10
 - Adds Arm64 job (that runs on ARMv8 hardware)