### PR TITLE
Add Apple M1 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,14 @@ if(WIN32 AND NOT DEFINED CMAKE_DEBUG_POSTFIX)
     set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
+if(APPLE)
+    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64")
+        set(CMAKE_OSX_ARCHITECTURES "arm64")
+    else()
+        set(CMAKE_OSX_ARCHITECTURES "x86_64")
+    endif()
+endif()
+
 # To prevent warnings from M$ compiler
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
Set CMAKE_OSX_ARCHITECTURES variable depending on CPU of Apple computers.  If it is set to "arm64", Apple Xcode compiler generates binaries of the native Apple M1 chips.  If "x86_64", the generated binaries are for Intel x86 chips.