### PR TITLE
Gate OpenMP and Jasper support w/ the enable option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ endif()
 MACRO_BOOL_TO_01(OPENMP_SUPPORT_CAN_BE_COMPILED LIBRAW_USE_OPENMP)
 
 # Jasper library check
-set(JASPER_FOUND false)
+set(JASPER_SUPPORT_CAN_BE_COMPILED false)
 if(ENABLE_JASPER)
     find_package(Jasper)
 
@@ -215,11 +215,12 @@ if(ENABLE_JASPER)
     if(JASPER_FOUND)
         add_definitions(-DUSE_JASPER)
         include_directories(${JASPER_INCLUDE_DIR})
+        set(JASPER_SUPPORT_CAN_BE_COMPILED true)
     endif()
 endif()
 
 # For registration to libraw_config.h
-MACRO_BOOL_TO_01(JASPER_FOUND LIBRAW_USE_REDCINECODEC)
+MACRO_BOOL_TO_01(JASPER_SUPPORT_CAN_BE_COMPILED LIBRAW_USE_REDCINECODEC)
 
 # For RawSpeed Codec Support
 
@@ -384,7 +385,7 @@ else()
     message(STATUS " Libraw will be compiled with example command-line programs ... NO")
 endif()
 
-if(JASPER_FOUND)
+if(JASPER_SUPPORT_CAN_BE_COMPILED)
     message(STATUS " Libraw will be compiled with RedCine codec support ........... YES")
 else()
     message(STATUS " Libraw will be compiled with RedCine codec support ........... NO")
@@ -502,7 +503,7 @@ if(JPEG8_FOUND)
     target_link_libraries(raw PUBLIC JPEG::JPEG)
 endif()
 
-if(JASPER_FOUND)
+if(JASPER_SUPPORT_CAN_BE_COMPILED)
     target_link_libraries(raw PUBLIC ${JASPER_LIBRARIES})
 endif()
 
@@ -569,7 +570,7 @@ if(JPEG8_FOUND)
     target_link_libraries(raw_r PUBLIC JPEG::JPEG)
 endif()
 
-if(JASPER_FOUND)
+if(JASPER_SUPPORT_CAN_BE_COMPILED)
     target_link_libraries(raw_r PUBLIC ${JASPER_LIBRARIES})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,12 +194,17 @@ endif()
 # For registration to libraw_config.h
 MACRO_BOOL_TO_01(JPEG8_FOUND LIBRAW_USE_DNGLOSSYCODEC)
 
+# OpenMP check
+set(OPENMP_SUPPORT_CAN_BE_COMPILED false)
 if(ENABLE_OPENMP)
-    find_package(OpenMP REQUIRED)
+    find_package(OpenMP)
+    if(OpenMP_FOUND)
+        set(OPENMP_SUPPORT_CAN_BE_COMPILED true)
+    endif()
 endif()
 
 # For registration to libraw_config.h
-MACRO_BOOL_TO_01(OpenMP_FOUND LIBRAW_USE_OPENMP)
+MACRO_BOOL_TO_01(OPENMP_SUPPORT_CAN_BE_COMPILED LIBRAW_USE_OPENMP)
 
 # Jasper library check
 set(JASPER_FOUND false)
@@ -361,7 +366,7 @@ message(STATUS "----------------------------------------------------------------
 message(STATUS " Libraw ${RAW_LIB_VERSION_STRING} configuration            <http://www.libraw.org>")
 message(STATUS "")
 
-if(OpenMP_FOUND)
+if(OPENMP_SUPPORT_CAN_BE_COMPILED)
     message(STATUS " Libraw will be compiled with OpenMP support .................. YES")
 else()
     message(STATUS " Libraw will be compiled with OpenMP support .................. NO")
@@ -478,7 +483,7 @@ if(WIN32)
     target_link_libraries(raw PUBLIC ws2_32)
 endif()
 
-if(OpenMP_FOUND)
+if(OPENMP_SUPPORT_CAN_BE_COMPILED)
     target_link_libraries(raw PUBLIC OpenMP::OpenMP_CXX)
     if(MINGW)
         target_compile_definitions(raw PRIVATE LIBRAW_FORCE_OPENMP)
@@ -545,7 +550,7 @@ if(WIN32)
     target_link_libraries(raw_r PUBLIC ws2_32)
 endif()
 
-if(OpenMP_FOUND)
+if(OPENMP_SUPPORT_CAN_BE_COMPILED)
     target_link_libraries(raw_r PUBLIC OpenMP::OpenMP_CXX)
     if(MINGW)
         target_compile_definitions(raw_r PRIVATE LIBRAW_FORCE_OPENMP)


### PR DESCRIPTION
Otherwise `OpenMP_FOUND` could already be TRUE from a master project if LibRaw is being built as a sub-project. See e.g. https://github.com/darktable-org/darktable/pull/12124