### PR TITLE
Don't try to find math library when compiling with Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ include(MacroOptionalFindPackage)
 
 # Math library check
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT EMSCRIPTEN)
     FIND_LIBRARY(MATH_LIBRARY m)
 endif()
 


### PR DESCRIPTION
Emcripten doesn't use a separate m library, so attempting to find it will fail and break the build.